### PR TITLE
Create privacy-policy.html

### DIFF
--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -1,0 +1,202 @@
+<html><body>
+<h2>Data Protection Notice</h2> Last updated: 22/11/2022 <h3>1. Who we are</h3>
+<p>Mastodon.me.uk (hereafter “we”, “us” or “the service”) is a non-profit <a
+        href="https://opencollective.com/mastodon-me-uk"
+        target="_blank">donation-based</a> service that provides Mastodon social
+    media accounts to the people in the UK (“you”). For the purpose of
+    connecting and interacting with other Mastodon or Fediverse accounts,
+    Mastodon.me.uk processes personal data from its users and users of other
+    instances with whom they interact. This data protection notice describes
+    what kind of personal data we process and on what legal basis, how long we
+    keep it and why, as well as your rights with respect to your data.</p>
+<p>Please do not hesitate to <a href="mailto:james@floppy.org.uk">contact us via
+        email</a> to for any question you might have with regard to this
+    document or the processing of your personal data.</p>
+<h3>2. Data protection summary</h3>
+<p>We dedicate our Mastodon instance Mastodon.me.uk to the people in the UK. Our
+    small team in London provides the non-profit <a
+        href="https://opencollective.com/mastodon-me-uk"
+        target="_blank">donation-based</a> service on a voluntary basis to offer
+    privacy-friendly micro-blogging accounts that our users typically employ for
+    networking, socialising and discussing ideas general discussion for users in
+    the UK.</p>
+<p>For the purpose of ensuring a secure interaction, the website of
+    Mastodon.me.uk stores the cookie ‘_mastodon_session’ with an identifier in
+    the browser of registered and unregistered website visitors until they close
+    their browser. For registered website visitors, the cookie ‘_session_id’
+    stores their login status until logout. Based on user consent, the website
+    stores as well push notification settings in the browser. For security and
+    debugging purposes, our server logs and stores visitor IP addresses for a
+    maximum of 14 days. After that time, all IP addresses are removed.</p>
+<p>Mastodon.me.uk processes profile data in the form of posts (toots),
+    subscriptions (following), subscribers (follower), content appreciations
+    (likes) and promotions (boosts) for publication in the context of profile
+    and post pages. For registered users we process your profile data to deliver
+    the service. For users of other instances, we store and display public
+    profile data and rely here on our legitimate interest until they object and
+    in any case when they delete their post or other data (unsubscribe, unlike,
+    unboost).</p>
+<p>If you contact Mastodon.me.uk via email or a (private) post, we use any
+    personal data that your message may contain (such as your email address or
+    name) only to respond to your message. We archive your message for at most
+    12 months. You are of course free to use a nickname and a pseudonymous email
+    address. We process messages from our registered users to deliver the
+    service and rely for users of other instances on their consent. We may also
+    process messages to comply with our legal obligations.</p>
+<p>The following information is provided according to Articles 12, 13 and 14 of
+    the <a
+        href="http://eur-lex.europa.eu/legal-content/EN/TXT/?uri=uriserv:OJ.L_.2016.119.01.0001.01.ENG&toc=OJ:L:2016:119:TOC"
+        target="_blank">GDPR</a>.</p>
+<h3>3. Data protection notice</h3> For the purposes of this notice: <p>
+    <strong>“User”</strong> means the natural person who interacts with
+    Mastodon.me.uk directly via the website or indirectly via third-party
+    applications compatible with ActivityPub.</p>
+<p><strong>“Registered user”</strong> means the users with a
+    Mastodon/ActivityPub profile.</p>
+<p><strong>“Profile data”</strong> means their posts (toots), subscriptions
+    (following), subscribers (follower) content appreciations (likes) and
+    promotions (boosts), bookmarks and profile settings.</p>
+<p><strong>“Subscribers”</strong> mean the accounts who follow a registered
+    user.</p>
+<p><strong>“Subscriptions”</strong> mean the accounts followed by a registered
+    user.</p>
+<p><strong>Scope and purpose of the processing</strong> This data protection
+    notice applies to the processing of personal data for the provision of the
+    microblogging service Mastodon.me.uk. It offers information on what personal
+    data is processed and how it is processed, and on your data subject rights.
+</p>
+<p><strong>Responsible for the processing</strong> The data controller is
+    Mastodon.me.uk in its capacity as the provider of the service.</p>
+<h4>Processing of personal data</h4>
+<p>Personal data processed by Mastodon.me.uk is accessible to its administration
+    team and, where necessary, to moderators on a need-to-know basis to ensure a
+    secure operation. User content is published or delivered according to the
+    user settings. For the provision of the service, Mastodon.me.uk employs the
+    data processors listed below that process personal data linked to the
+    service solely on the written instruction from Mastodon.me.uk:</p>
+<ul>
+    <li>Server hosting from <a href="https://masto.host"
+            target="_blank">Mastohost</a></li>
+    <!-- TODO:  <li>Email notifications delivery from <a
+            href="https://www.notifications-provider.com"
+            target="_blank">Notifications_Provider, Provider_City</a></li>
+    <li>Email mailbox from <a href="https://inbox-provider.com"
+            target="_blank">Inbox_Provider, Provider_City</a></li> -->
+    <li>Donations processing from <a href="https://opencollective.com/"
+            target="_blank">OpenCollective, with donation host "Accountable"
+            from the Social Change Nest CIC, London</a><!----></li>
+</ul><strong>(a) Website Visitors</strong>
+<p>The Mastodon.me.uk website and APIs process the IP addresses and other
+    metadata (as specified below) of its visitors. When accessing the service,
+    an encrypted connection to its web server is established. To display the
+    content correctly on the visitor’s computer or other terminal devices, the
+    following data is processed in accordance with the HTTP and TCP/IP protocol:
+</p>
+<ul>
+    <li>IP address of the visitor’s internet connection</li>
+    <li>Operating system and operating system version of the visitor’s terminal
+    </li>
+    <li>Web browser and browser version</li>
+    <li>Date of access to the website</li>
+    <li>HTTP cookie ‘_mastodon_session’ (for the duration of the website visit)
+    </li>
+</ul>
+<p>This is required for the request, processing, and display of profile data and
+    other content on the service. After each page visit, some of the data are
+    stored in the account profile (if logged in) and server logs. These logs
+    serve the purpose of maintenance and security of the server and personal
+    data herein is deleted after 14 days. Furthermore, the website employs the
+    cookie ‘_session_id’ to store the login status of registered users until
+    logout or until a year after the last website visit. The website also stores
+    the notifications settings in the browser. This processing is based on
+    Article 6 (1) (b) of the GDPR (‘processing is necessary for the performance
+    of a contract’). This includes processing carried out in order to comply
+    with the necessary technical and organisational protection measures.</p>
+<p><strong>(b) Contributors from third-party services</strong></p>
+<p>Mastodon.me.uk processes personal data when users of third-party services
+    with ActivityPub support interact with its accounts. To enrich public
+    profile pages with profile data, the following data is processed in
+    accordance with the requirements of the ActivityPub protocol:</p>
+<ul>
+    <li>IP address of the third-party service</li>
+    <li>Name of the user’s terminal software</li>
+    <li>Display name, account name, and profile picture</li>
+    <li>Current date and time</li>
+    <li>Profile data</li>
+</ul>
+<p>Private messages are not end-to-end encrypted and are therefore in principle
+    accessible to the Mastodon.me.uk administrators.</p>
+<p>This processing is necessary to provide a federated Mastodon instance and
+    therefore based on Article 6 (1) (f) GDPR (‘processing is in our legitimate
+    interest’) with the exception of personal data that is not required such as
+    the display name and profile picture, the processing of which is based on
+    Article 6 (1) (a) GDPR (‘consent’). Mastodon.me.uk stores profile data from
+    subscriptions from compatible third-party services until it receives via
+    that service or directly from the user a request for deletion or objection
+    (unsubscribe, unlike, unboost).</p><strong>(c) Registered users</strong>
+<p>Mastodon.me.uk limits registrations to users it assumes to be
+    people in the UK. Mastodon.me.uk reserves the right to refuse the provision
+    of the service to any given user for any reason. To set up accounts and
+    manage them subsequently, the following data from registered users is
+    processed:</p>
+<ul>
+    <li>Display name, account name, profile picture and header image </li>
+    <li>Login credentials consisting of an email address </li>
+    <li>Account description/biography </li>
+    <li>Content (toots), promoted, and appreciated content </li>
+    <li>Private messages (sent and received) </li>
+    <li>Subscriptions and their recent content </li>
+    <li>Logged-in sessions (terminal software, time and date, IP address) </li>
+</ul>
+<p>If registered users post profile data, the previous section applies
+    accordingly. Note that updating subscribers and posting profile data
+    (including profile mentions) requires disclosure of personal data to the
+    service of the recipients. Depending on their Mastodon server’s geographic
+    location, the disclosure can possibly involve international data transfers
+    that are outside of Mastodon.me.uk’s control.</p>
+<p>The registered user’s name and display name, profile picture and header,
+    description, subscriptions, the own and promoted content, the content of
+    their subscriptions, as well as their given feedback is published on their
+    profile page.</p>
+<p>This processing is based on Article 6 (1) (b) of the GDPR (‘processing is
+    necessary for the performance of a contract’) with the exception of personal
+    data that is not required such as the display name and profile picture, the
+    processing of which is based on Article 6 (1) (a) GDPR (‘consent’). Profile
+    data is retained until the account is deleted.</p>
+<p>Registered users are responsible for the use of their accounts and their own
+    compliance with the GDPR as separate controllers when they post personal
+    data of other people.</p><strong>(d) Donations via OpenCollective</strong>
+<p>Users can make donations for the operation of Mastodon.me.uk via OpenCollective,
+    which processes personal data according to their own data protection notice.
+</p><strong>(e) Contacting us by email</strong>
+<p>If you contact Mastodon.me.uk via email or a Mastodon private message, any
+    personal data that your message may contain (such as your email address or
+    name) will only be used to respond to your message and may be stored as part
+    of an email archive. You are of course free to use a nickname and a
+    pseudonymous email address. Such personal data will be deleted after 12
+    months.</p>
+<h4>Exercise your rights</h4>
+<p>You have the right to request from us access to and rectification or erasure
+    of your personal data or restriction of processing concerning you or, where
+    applicable, the right to object to processing or the right to data
+    portability. Where applicable, you also have the right to withdraw your
+    consent at any time. Please note that withdrawing your consent does not
+    affect the lawfulness of processing based on consent before its withdrawal.
+</p>
+<p>Please find more information on your rights on the website of the <a
+        href="https://ec.europa.eu/info/law/law-topic/data-protection/reform/rights-citizens/my-rights/what-are-my-rights_en"
+        target="_blank">European Commission</a>.</p>
+<p>You have, in any case, the right to lodge a complaint with the <a
+        href="https://edpb.europa.eu/about-edpb/about-edpb/members_en"
+        target="_blank">data protection authority</a> as a supervisory
+    authority.</p>
+<h3>Acknowledgments</h3>
+<p>These terms are based on the <a href="https://eupolicy.social/terms"
+        target="_blank">terms initially published by eupolicy.social</a> and
+    made more accessible by the <a
+        href="http://blog.riemann.cc/projects/mastodon-privacy-policy-generator/"
+        target="_blank">Mastodon Privacy Policy Generator</a> in its version
+    v1.1 as of 22/11/2022. This text is free to be adapted and remixed under the
+    terms of the <a href="https://creativecommons.org/licenses/by/4.0/"
+        target="_blank">CC-BY (Attribution 4.0 International) license</a>. </p>
+  </body></html>


### PR DESCRIPTION
Based on the generator: https://blog.riemann.cc/projects/mastodon-privacy-policy-generator/
TODO: check email address - currently james@floppy.org.uk but needs 12 month auto-deletion policy for mastodon enquiries. Maybe should be a different mailbox/address?
Also, should this be updated to include UK Data Protection Information?
Finally are all web server logs deleted after 14 days?