### PR TITLE
Use `TOKEN` everywhere

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-all: lint ansible keys
+all: lint ansible tokens
 
 ansible:
 	ansible-playbook --extra-vars="env=dev" playbook/play.yaml
@@ -6,5 +6,5 @@ ansible:
 lint:
 	ansible-lint
 
-keys:
+tokens:
 	python playbook/scripts/key_tracker.py

--- a/playbook/API-KEYS.md
+++ b/playbook/API-KEYS.md
@@ -1,5 +1,0 @@
-All API keys required for this playbook:
-
-|Secret name|scope|
-|---|---|
-|MASTODON_READ_ONLY_KEY|admin:read|

--- a/playbook/API-TOKENS.md
+++ b/playbook/API-TOKENS.md
@@ -1,4 +1,4 @@
-API tokens required:
+All API tokens required for this playbook:
 
 |Secret name|scope|
 |---|---|

--- a/playbook/scripts/key_tracker.py
+++ b/playbook/scripts/key_tracker.py
@@ -4,23 +4,23 @@ from pathlib import Path
 
 readmes = filter(lambda x: x.name == "README.md", Path("playbook", "roles").glob("*/*"))
 
-keys = []
+tokens = []
 for readme in readmes:
     lines = readme.read_text().split("\n")
     for line in lines:
-        if re.match(r"\|MASTODON_.*_KEY\|", line):
-            if line not in keys:
-                keys.append(line)
+        if re.match(r"\|MASTODON_.*_TOKEN\|", line):
+            if line not in tokens:
+                tokens.append(line)
 
-keys.sort(key=lambda x: x.split("|")[3])
+tokens.sort(key=lambda x: x.split("|")[3])
 
-text = """All API keys required for this playbook:
+text = """All API tokens required for this playbook:
 
 |Secret name|scope|
 |---|---|
 """
 
-text += "\n".join(keys)
+text += "\n".join(tokens)
 text += "\n"
 
-Path("playbook", "API-KEYS.md").write_text(text)
+Path("playbook", "API-TOKENS.md").write_text(text)


### PR DESCRIPTION
I had used `KEY` in some places. Mastodon calls it a token, we should call it a token